### PR TITLE
ci: [Update] Add pytest with GitHub Actions 

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -22,3 +22,6 @@ Dockerfile
 docker-compose.yml
 images
 README.md
+test
+.pytest_cache
+.github

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,17 +1,20 @@
-name: Pylint
+name: pytest
 on: [pull_request]
 
 jobs:
-  lint:
-    name: Run Pylint
+  pytest:
+    name: Run tests with pytest
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -35,4 +38,4 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - run: pylint main.py ./notifiers
+      - run: pytest

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,7 @@ up:
 	docker-compose up
 
 lint:
-	docker-compose run --rm app pylint main.py ./notifiers ./message/message.py
+	docker-compose run --rm app pylint main.py ./notifiers ./message/message.py ./test
+
+pytest:
+	docker-compose run --rm app pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Stooqifier
 ====
 ![Pylint](https://github.com/f-teruhisa/stooqifier/workflows/Pylint/badge.svg)
+[![Pytest](https://github.com/f-teruhisa/stooqifier/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/f-teruhisa/stooqifier/actions/workflows/pytest.yml)
 
 Stooqifier is an automatic stock price [Slack](https://slack.com/intl/en-in/) notification with chart image script that with [pandas-datareader](https://github.com/pydata/pandas-datareader) call [Stooq.com](https://stooq.com/) API.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pandas==1.2.0
 pillow==8.1.0; python_version >= '3.6'
 pylint==2.6.0
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pytest==6.2.3
 python-dateutil==2.8.1
 python-dotenv==0.15.0
 pytz==2020.5

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,40 @@
+"""
+sys: For import `message` modules from `message/message`
+pytest: For using fixture with pytest
+"""
+
+import sys
+import pytest
+sys.path.append('.')
+
+@pytest.fixture
+def ohlcv():
+    """
+    Create OHLCV test data
+    :return: Hash
+    """
+    data = {
+        'Date': '2020-12-29',
+        'Open': '7620',
+        'High': '8070',
+        'Low': '7610',
+        'Close': '8060',
+        'Volume': '823700'
+    }
+    return data
+
+@pytest.fixture
+def prev_ohlcv():
+    """
+    Create yesterday OHLCV test data
+    :return: Hash
+    """
+    data = {
+        'Date': '2020-12-28',
+        'Open': '7500',
+        'High': '8000',
+        'Low': '7500',
+        'Close': '8000',
+        'Volume': '820000'
+    }
+    return data

--- a/test/message/test_message.py
+++ b/test/message/test_message.py
@@ -1,0 +1,26 @@
+"""
+Python modules
+datetime: Get the date for test date.
+message: Test target class
+"""
+
+import datetime
+from message import message
+
+def test__content(ohlcv, prev_ohlcv):
+    """
+    Test method for Message().__content
+    :param ohlcv: Hash
+    :param prev_ohlcv: Hash
+    :return: Result assertion
+    """
+    date = datetime.date(2020, 12, 28)
+    content = message.Message(date, ohlcv, prev_ohlcv).content
+    expected_text = "本日は2020年12月28日です。\n" \
+               "取得可能な最新日付の株価情報をお知らせします。 \n\n" \
+                    "*始値* 7,620 _[前日比: △120_ (1.60%)]\n" \
+                    "*高値* 8,070 _[前日比: △70_ (0.88%)]\n" \
+                    "*安値* 7,610 _[前日比: △110_ (1.47%)]\n" \
+                    "*終値* 8,060 _[前日比: △60_ (0.75%)]\n" \
+                    "*出来高* 823,700 _[前日比: △3,700_ (0.45%)]\n"
+    assert content == expected_text


### PR DESCRIPTION
close: #2

Make it possible to run pytest with GitHub Actions.

To make sure that ready to write test code with pytest, write a test code for `__content()` method of the `Message()` class.

Also, added `pytest.yml` to `workflow` to run pytest with GitHub Actions.