### PR TITLE
[Update] Devide the OHLCV calculation from Message class 

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -35,4 +35,4 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - run: pylint main.py ./notifiers
+      - run: pylint main.py ./notifiers ./message ./test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ up:
 	docker-compose up
 
 lint:
-	docker-compose run --rm app pylint main.py ./notifiers ./message/message.py ./test
+	docker-compose run --rm app pylint main.py ./notifiers ./message ./test
 
 pytest:
 	docker-compose run --rm app pytest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Stooqifier
 ====
-![Pylint](https://github.com/f-teruhisa/stooqifier/workflows/Pylint/badge.svg)
-[![Pytest](https://github.com/f-teruhisa/stooqifier/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/f-teruhisa/stooqifier/actions/workflows/pytest.yml)
+[![Pylint](https://github.com/f-teruhisa/stooqifier/actions/workflows/pylint.yml/badge.svg)](https://github.com/f-teruhisa/stooqifier/actions/workflows/pylint.yml)
+[![pytest](https://github.com/f-teruhisa/stooqifier/actions/workflows/pytest.yml/badge.svg)](https://github.com/f-teruhisa/stooqifier/actions/workflows/pytest.yml)
 
 Stooqifier is an automatic stock price [Slack](https://slack.com/intl/en-in/) notification with chart image script that with [pandas-datareader](https://github.com/pydata/pandas-datareader) call [Stooq.com](https://stooq.com/) API.
 

--- a/message/message.py
+++ b/message/message.py
@@ -1,131 +1,58 @@
 """
-re: Matching with regex for appending plus/minus into number of stock price
+ohlcv: OHLCV calculation value class module
 """
-import re
+from message import ohlcv
 
+# pylint: disable=R0903
+# Too few public methods (1/2) (too-few-public-methods)
+# The number of public methods has been reduced due to devide the class responsibilities.
 class Message():
     """
-    Value object class for noitification message
+    Value object class for notification message
     """
 
-    def __init__(self, date, ohlcv, prev_ohlcv):
+    def __init__(self, date, ohlcv_data, prev_ohlcv_data):
+        data = ohlcv.Ohlcv(ohlcv_data, prev_ohlcv_data)
         self.date = date
-        self.prev_compared_ohlcv = self.__compared_numbers_previous_day(ohlcv, prev_ohlcv)
-        self.prev_compared_percent_ohlcv = self.__compared_percet_previous_day(ohlcv, prev_ohlcv)
-        self.content = self.__content(ohlcv)
+        self.prev_compared_ohlcv = data.compared_numbers_previous_day
+        self.prev_compared_percent_ohlcv = data.compared_percent_previous_day
+        self.content = self.__content(ohlcv_data)
 
-    def __content(self, ohlcv):
+    def __content(self, ohlcv_data):
         """
         Create params data for sending Slack notification with API.
-        :param dict[str, str, str, str, str, str] ohlcv:
-        :type ohlcv: {
+        :param ohlcv_data: OHLCV data of stock price
+        :type ohlcv_data: hash
+            example: {
             'Date': '2020-12-29',
             'Open': '7620',
             'High': '8070',
-			'Low': '7610',
-			'Close': '8060',
-			'Volume': '823700'
+            'Low': '7610',
+            'Close': '8060',
+            'Volume': '823700'
         }
         :return: String
         """
         text = f"本日は{self.date.strftime('%Y年%m月%d日')}です。\n" \
                f"取得可能な最新日付の株価情報をお知らせします。 \n\n" \
-               f"*始値* {self.format_data_to_message(ohlcv, 'Open')}" \
-               f"*高値* {self.format_data_to_message(ohlcv, 'High')}" \
-               f"*安値* {self.format_data_to_message(ohlcv, 'Low')}" \
-               f"*終値* {self.format_data_to_message(ohlcv, 'Close')}" \
-               f"*出来高* {self.format_data_to_message(ohlcv, 'Volume')}"
+               f"*始値* {self.format_data_to_message(ohlcv_data, 'Open')}" \
+               f"*高値* {self.format_data_to_message(ohlcv_data, 'High')}" \
+               f"*安値* {self.format_data_to_message(ohlcv_data, 'Low')}" \
+               f"*終値* {self.format_data_to_message(ohlcv_data, 'Close')}" \
+               f"*出来高* {self.format_data_to_message(ohlcv_data, 'Volume')}"
         return text
 
-    def format_data_to_message(self, ohlcv, category):
+    def format_data_to_message(self, ohlcv_data, category):
         """
         Format message with ohlcv data
-        :param ohlcv:
-        :param category:
+        :param ohlcv_data: OHLCV data of stock price
+        :type ohlcv_data: hash
+        :param category: Any of the items in OHLCV
+        :type string
         :return: string
         """
-        current = f"{int(ohlcv[f'{category}']):,d} "
+        current = f"{int(ohlcv_data[f'{category}']):,d} "
         compared_number = f"_[前日比: {self.prev_compared_ohlcv[f'{category}']}_ "
         compared_percentage = f"({self.prev_compared_percent_ohlcv[f'{category}']})]\n"
         message = current + compared_number + compared_percentage
         return message
-
-    @classmethod
-    def __compared_percet_previous_day(cls, ohlcv, prev_ohlcv):
-        """
-        Compare ohlcv percentage data with prev_ohlcv.
-        :param dict[str, str, str, str, str, str] ohlcv:
-        :type ohlcv, prev_ohlcv: {
-            'Date': '2020-12-29',
-            'Open': '7620',
-            'High': '8070',
-            'Low': '7610',
-            'Close': '8060',
-            'Volume': '823700'
-        }
-        :return: dict
-        """
-        prev_compared_percentage_ohlcv = dict(
-            Open=cls.calc_percentage_ohlcv(int(ohlcv['Open']), int(prev_ohlcv['Open'])),
-            High=cls.calc_percentage_ohlcv(int(ohlcv['High']), int(prev_ohlcv['High'])),
-            Low=cls.calc_percentage_ohlcv(int(ohlcv['Low']), int(prev_ohlcv['Low'])),
-            Close=cls.calc_percentage_ohlcv(int(ohlcv['Close']), int(prev_ohlcv['Close'])),
-            Volume=cls.calc_percentage_ohlcv(int(ohlcv['Volume']), int(prev_ohlcv['Volume']))
-        )
-        return prev_compared_percentage_ohlcv
-
-    @classmethod
-    def calc_percentage_ohlcv(cls, current, prev):
-        """
-        Calculate compare percentage with previous day
-        (current_numbers / previous_day_number) / previous_day_number
-        :param current:
-        :param prev:
-        :return: string
-        """
-        percentage = '{:.2%}'.format((int(current) - int(prev)) / int(prev))
-        return percentage
-
-    @classmethod
-    def __compared_numbers_previous_day(cls, ohlcv, prev_ohlcv):
-        """
-        Compare ohlcv data with prev_ohlcv.
-        :param dict[str, str, str, str, str, str] ohlcv:
-        :type ohlcv, prev_ohlcv: {
-            'Date': '2020-12-29',
-            'Open': '7620',
-            'High': '8070',
-            'Low': '7610',
-            'Close': '8060',
-            'Volume': '823700'
-        }
-        :return: dict
-        """
-        prev_compared_ohlcv = dict(
-            Open=cls.append_triangle(int(ohlcv['Open']) - int(prev_ohlcv['Open'])),
-            High=cls.append_triangle(int(ohlcv['High']) - int(prev_ohlcv['High'])),
-            Low=cls.append_triangle(int(ohlcv['Low']) - int(prev_ohlcv['Low'])),
-            Close=cls.append_triangle(int(ohlcv['Close']) - int(prev_ohlcv['Close'])),
-            Volume=cls.append_triangle(int(ohlcv['Volume']) - int(prev_ohlcv['Volume']))
-        )
-        return prev_compared_ohlcv
-
-    @classmethod
-    def append_triangle(cls, number):
-        """
-        Add ▲ when the previous day's value is negative
-        and △ when the previous day's value is positive
-        in front of the number.
-        :param number:
-        :return: number:
-        """
-        is_minus = re.match(r'-', str(number))
-
-        if is_minus:
-            appended_number = str('{:,}'.format(number)).replace('-', '▲')
-        elif number == 0:
-            appended_number = '{:,}'.format(number)
-        else:
-            appended_number = '△' + str('{:,}'.format(number))
-
-        return appended_number

--- a/message/ohlcv.py
+++ b/message/ohlcv.py
@@ -1,0 +1,100 @@
+"""
+re: Matching with regex for appending plus/minus into number of stock price
+"""
+import re
+
+class Ohlcv():
+    """
+    Value object class for OHLCV calculation
+    """
+    def __init__(self, ohlcv, prev_ohlcv):
+        """
+        Compare ohlcv percentage data with prev_ohlcv.
+        :param ohlcv: OHLCV data of stock price
+        :type
+            ohlcv: hash
+            example: {
+            'Date': '2020-12-29',
+            'Open': '7620',
+            'High': '8070',
+            'Low': '7610',
+            'Close': '8060',
+            'Volume': '823700'
+        }
+        :param prev_ohlcv: OHLCV data of stock price of yesterday
+        :type
+            prev_ohlcv: hash
+            example: {
+            'Date': '2020-12-29',
+            'Open': '7620',
+            'High': '8070',
+            'Low': '7610',
+            'Close': '8060',
+            'Volume': '823700'
+        }
+        """
+        self.ohlcv = ohlcv
+        self.prev_ohlcv = prev_ohlcv
+        self.compared_numbers_previous_day = self.__compared_numbers_previous_day()
+        self.compared_percent_previous_day = self.__compared_percent_previous_day()
+
+    def __compared_numbers_previous_day(self):
+        """
+        Compare ohlcv data with previous ohlcv.
+        :return: dict
+        """
+        prev_compared_ohlcv = dict(
+            Open=self.append_triangle(int(self.ohlcv['Open']) - int(self.prev_ohlcv['Open'])),
+            High=self.append_triangle(int(self.ohlcv['High']) - int(self.prev_ohlcv['High'])),
+            Low=self.append_triangle(int(self.ohlcv['Low']) - int(self.prev_ohlcv['Low'])),
+            Close=self.append_triangle(int(self.ohlcv['Close']) - int(self.prev_ohlcv['Close'])),
+            Volume=self.append_triangle(int(self.ohlcv['Volume']) - int(self.prev_ohlcv['Volume']))
+        )
+        return prev_compared_ohlcv
+
+    @staticmethod
+    def append_triangle(number):
+        """
+        Add ▲ when the previous day's value is negative
+        and △ when the previous day's value is positive
+        in front of the number.
+        :param number: Number of the target to be given a triangle
+        :type: number
+        :return: string
+        """
+        is_minus = re.match(r'-', str(number))
+
+        if is_minus:
+            appended_number = str('{:,}'.format(number)).replace('-', '▲')
+        elif number == 0:
+            appended_number = '{:,}'.format(number)
+        else:
+            appended_number = '△' + str('{:,}'.format(number))
+
+        return appended_number
+
+    def __compared_percent_previous_day(self):
+        """
+        Compare ohlcv percentage data with previous ohlcv.
+        :return: dict
+        """
+        prev_compared_percentage_ohlcv = dict(
+            Open=self.calc_percentage(int(self.ohlcv['Open']), int(self.prev_ohlcv['Open'])),
+            High=self.calc_percentage(int(self.ohlcv['High']), int(self.prev_ohlcv['High'])),
+            Low=self.calc_percentage(int(self.ohlcv['Low']), int(self.prev_ohlcv['Low'])),
+            Close=self.calc_percentage(int(self.ohlcv['Close']), int(self.prev_ohlcv['Close'])),
+            Volume=self.calc_percentage(int(self.ohlcv['Volume']), int(self.prev_ohlcv['Volume']))
+        )
+        return prev_compared_percentage_ohlcv
+
+    @staticmethod
+    def calc_percentage(current, prev):
+        """
+        Calculate compare percentage with previous day
+        (current_number / previous_day_number) / previous_day_number
+        :param current: current_number
+        :param prev: previous_day_number
+        :return: string
+        """
+        percentage = '{:.2%}'.format((int(current) - int(prev)) / int(prev))
+        return percentage

--- a/notifiers/slack.py
+++ b/notifiers/slack.py
@@ -30,7 +30,7 @@ class Slack():
         """
         Setting parameters when request with slack's files.upload API
         API docs: https://api.slack.com/methods/files.upload
-        :return: dict
+        :return: hash
         """
         dotenv_path = join(dirname(__file__), '.env')
         load_dotenv(dotenv_path)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,17 +1,19 @@
 """
+datetime: Get the date for test date.
 sys: For import `message` modules from `message/message`
 pytest: For using fixture with pytest
 """
 
+import datetime
 import sys
 import pytest
 sys.path.append('.')
 
 @pytest.fixture
-def ohlcv():
+def ohlcv_data():
     """
     Create OHLCV test data
-    :return: Hash
+    :return: hash
     """
     data = {
         'Date': '2020-12-29',
@@ -24,10 +26,10 @@ def ohlcv():
     return data
 
 @pytest.fixture
-def prev_ohlcv():
+def prev_ohlcv_data():
     """
     Create yesterday OHLCV test data
-    :return: Hash
+    :return: hash
     """
     data = {
         'Date': '2020-12-28',
@@ -38,3 +40,11 @@ def prev_ohlcv():
         'Volume': '820000'
     }
     return data
+
+@pytest.fixture
+def today_datetime():
+    """
+    Today datetime
+    :return: datetime
+    """
+    return datetime.date.today()

--- a/test/message/test_message.py
+++ b/test/message/test_message.py
@@ -1,22 +1,20 @@
 """
-Python modules
-datetime: Get the date for test date.
 message: Test target class
 """
 
-import datetime
 from message import message
 
-def test__content(ohlcv, prev_ohlcv):
+def test__content(today_datetime, ohlcv_data, prev_ohlcv_data):
     """
-    Test method for Message().__content
-    :param ohlcv: Hash
-    :param prev_ohlcv: Hash
+    Test method for `Message().__content`
+    :param ohlcv: OHLCV data of stock price
+    :type: hash
+    :param prev_ohlcv: OHLCV data of stock price of yesterday
+    :type: hash
     :return: Result assertion
     """
-    date = datetime.date(2020, 12, 28)
-    content = message.Message(date, ohlcv, prev_ohlcv).content
-    expected_text = "本日は2020年12月28日です。\n" \
+    content = message.Message(today_datetime, ohlcv_data, prev_ohlcv_data).content
+    expected_text = f"本日は{today_datetime.strftime('%Y年%m月%d日')}です。\n" \
                "取得可能な最新日付の株価情報をお知らせします。 \n\n" \
                     "*始値* 7,620 _[前日比: △120_ (1.60%)]\n" \
                     "*高値* 8,070 _[前日比: △70_ (0.88%)]\n" \
@@ -24,3 +22,18 @@ def test__content(ohlcv, prev_ohlcv):
                     "*終値* 8,060 _[前日比: △60_ (0.75%)]\n" \
                     "*出来高* 823,700 _[前日比: △3,700_ (0.45%)]\n"
     assert content == expected_text
+
+def test_format_data_to_message(today_datetime, ohlcv_data, prev_ohlcv_data):
+    """
+    Test method for `Message()._test_format_data_to_message()`
+    :param ohlcv: OHLCV data of stock price
+    :type: hash
+    :param prev_ohlcv: OHLCV data of stock price of yesterday
+    :type: hash
+    :return: Result assertion
+    """
+    category = 'Open'
+    formatted_message = message.Message(today_datetime, ohlcv_data, prev_ohlcv_data).format_data_to_message(ohlcv_data, category)
+    expected_message = "7,620 _[前日比: △120_ (1.60%)]\n"
+    
+    assert formatted_message == expected_message

--- a/test/message/test_ohlcv.py
+++ b/test/message/test_ohlcv.py
@@ -1,0 +1,88 @@
+"""
+ohlcv: Test target class
+"""
+
+from message import ohlcv
+
+def test__compared_numbers_previous_day(ohlcv_data, prev_ohlcv_data):
+    """
+    Test method for `Ohlcv().__compared_numbers_previous_day`
+    :param ohlcv: OHLCV data of stock price
+    :type: hash
+    :param prev_ohlcv: OHLCV data of stock price of yesterday
+    :type: hash
+    :return: Result assertion
+    """
+    compared_data = ohlcv.Ohlcv(ohlcv_data, prev_ohlcv_data).compared_numbers_previous_day
+    expected_data = dict(
+        Open='△120',
+        High='△70',
+        Low='△110',
+        Close='△60',
+        Volume='△3,700'
+    )
+    assert compared_data == expected_data
+    
+def test___compared_percent_previous_day(ohlcv_data, prev_ohlcv_data):
+    """
+    Test method for `Ohlcv().__compared_percent_previous_day`
+    :param ohlcv: OHLCV data of stock price
+    :type: hash
+    :param prev_ohlcv: OHLCV data of stock price of yesterday
+    :type: hash
+    :return: Result assertion
+    """
+    compared_data = ohlcv.Ohlcv(ohlcv_data, prev_ohlcv_data).compared_percent_previous_day
+    expected_data = dict(
+        Open='1.60%',
+        High='0.88%',
+        Low='1.47%',
+        Close='0.75%',
+        Volume='0.45%'
+    )
+    assert compared_data == expected_data
+    
+def test_append_triangle(ohlcv_data, prev_ohlcv_data):
+    """
+    Test method for `Ohlcv().append_triangle`
+    :param ohlcv: OHLCV data of stock price
+    :type: hash
+    :param prev_ohlcv: OHLCV data of stock price of yesterday
+    :type: hash
+    :return: Result assertion
+    """
+    ohlcv_instance = ohlcv.Ohlcv(ohlcv_data, prev_ohlcv_data)
+    
+    plus_number = 1000
+    minus_number = -1000
+    zero_number = 0
+    
+    expected_plus_str = '△1,000'
+    expected_minus_str = '▲1,000'
+    expected_zero_str = '0'
+    
+    appended_plus_number = ohlcv_instance.append_triangle(plus_number)
+    appended_minus_number = ohlcv_instance.append_triangle(minus_number)
+    appended_zero_number = ohlcv_instance.append_triangle(zero_number)
+
+    assert appended_plus_number == expected_plus_str
+    assert appended_minus_number == expected_minus_str
+    assert appended_zero_number == expected_zero_str
+
+def test_calc_percentage(ohlcv_data, prev_ohlcv_data):
+    """
+    Test method for `Ohlcv().calc_percentage()`
+    :param ohlcv: OHLCV data of stock price
+    :type: hash
+    :param prev_ohlcv: OHLCV data of stock price of yesterday
+    :type: hash
+    :return: Result assertion
+    """
+    ohlcv_instance = ohlcv.Ohlcv(ohlcv_data, prev_ohlcv_data)
+    
+    current_number = 10000
+    prev_number = 8000
+
+    calcurated_percentage = ohlcv_instance.calc_percentage(current_number, prev_number)
+
+    assert calcurated_percentage == '25.00%'


### PR DESCRIPTION
close: #13

For the purpose of refactoring, split the handling of OHLCV data from the `Message` class.

Let the `Message` class only create the Slack notification text, and let the `Ohlcv` class do the data calculation.